### PR TITLE
Add imperative style of development; fix inherit

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,9 +5,6 @@ from fastapi_router_controller import Controller, ControllersTags
 from fastapi import APIRouter, Depends, FastAPI, Query
 from fastapi.testclient import TestClient
 
-router = APIRouter()
-controller = Controller(router, openapi_tag={'name': 'sample_controller'})
-
 
 class SampleObject(BaseModel):
     id: str
@@ -16,55 +13,59 @@ class SampleObject(BaseModel):
 def get_x():
     class Foo:
         def create(self):
-            return 'XXX'
+            return "XXX"
 
     return Foo()
 
 
 def get_y():
     try:
-        yield 'get_y_dep'
+        yield "get_y_dep"
     finally:
-        print('get_y done')
+        print("get_y done")
 
 
 class Filter(BaseModel):
     foo: str
 
 
-# With the 'resource' decorator define the controller Class linked to the Controller router arguments
-@controller.resource()
-class SampleController:
-    def __init__(self, x=Depends(get_x)):
-        self.x = x
+def create_app_declerative():
+    router = APIRouter()
+    controller = Controller(router, openapi_tag={"name": "sample_controller"})
 
-    @controller.route.get(
-        '/',
-        tags=['sample_controller'],
-        summary='return a sample object',
-        response_model=SampleObject,
-    )
-    def root(
-        self,
-        id: str = Query(..., title='itemId', description='The id of the sample object'),
-    ):
-        id += self.x.create()
-        return SampleObject(id=id)
+    # With the 'resource' decorator define the controller Class linked to the Controller router arguments
+    @controller.resource()
+    class SampleController:
+        def __init__(self, x=Depends(get_x)):
+            self.x = x
 
-    @controller.route.post(
-        '/hello', response_model=SampleObject,
-    )
-    def hello(self, f: Filter, y=Depends(get_y)):
-        _id = f.foo
-        _id += y
-        _id += self.x.create()
-        return SampleObject(id=_id)
+        @controller.route.get(
+            "/",
+            tags=["sample_controller"],
+            summary="return a sample object",
+            response_model=SampleObject,
+        )
+        def root(
+            self,
+            id: str = Query(
+                ..., title="itemId", description="The id of the sample object"
+            ),
+        ):
+            id += self.x.create()
+            return SampleObject(id=id)
 
+        @controller.route.post(
+            "/hello", response_model=SampleObject,
+        )
+        def hello(self, f: Filter, y=Depends(get_y)):
+            _id = f.foo
+            _id += y
+            _id += self.x.create()
+            return SampleObject(id=_id)
 
-def create_app():
     app = FastAPI(
-        title='A sample application using fastapi_router_controller',
-        version='0.1.0',
+        title="A sample application using fastapi_router_controller",
+        version="0.1.0",
         openapi_tags=ControllersTags,
     )
 
@@ -72,17 +73,78 @@ def create_app():
     return app
 
 
-class TestRoutes(unittest.TestCase):
+def create_app_imperative():
+    class SampleController:
+        def __init__(self, x=Depends(get_x)):
+            self.x = x
+
+        def root(
+            self,
+            id: str = Query(
+                ..., title="itemId", description="The id of the sample object"
+            ),
+        ):
+            id += self.x.create()
+            return SampleObject(id=id)
+
+        def hello(self, f: Filter, y=Depends(get_y)):
+            _id = f.foo
+            _id += y
+            _id += self.x.create()
+            return SampleObject(id=_id)
+
+    app = FastAPI(
+        title="A sample application using fastapi_router_controller",
+        version="0.1.0",
+        openapi_tags=ControllersTags,
+    )
+
+    router = APIRouter()
+    controller = Controller(router, openapi_tag={"name": "sample_controller"})
+
+    SampleController = controller.add_resource(SampleController)
+    controller.route.add_api_route(
+        "/",
+        SampleController.root,
+        tags=["sample_controller"],
+        summary="return a sample object",
+        response_model=SampleObject,
+        methods=["GET"],
+    )
+    controller.route.add_api_route(
+        "/hello", SampleController.hello, response_model=SampleObject, methods=["POST"]
+    )
+    app.include_router(SampleController.router())
+    return app
+
+
+class TestRoutesDeclerative(unittest.TestCase):
     def setUp(self):
-        app = create_app()
+        app = create_app_declerative()
         self.client = TestClient(app)
 
     def test_root(self):
-        response = self.client.get('/?id=12')
+        response = self.client.get("/?id=12")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {'id': '12XXX'})
+        self.assertEqual(response.json(), {"id": "12XXX"})
 
     def test_hello(self):
-        response = self.client.post('/hello', json={'foo': 'WOW'})
+        response = self.client.post("/hello", json={"foo": "WOW"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {'id': 'WOWget_y_depXXX'})
+        self.assertEqual(response.json(), {"id": "WOWget_y_depXXX"})
+
+
+class TestRoutesImperative(unittest.TestCase):
+    def setUp(self):
+        app = create_app_imperative()
+        self.client = TestClient(app)
+
+    def test_root(self):
+        response = self.client.get("/?id=12")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": "12XXX"})
+
+    def test_hello(self):
+        response = self.client.post("/hello", json={"foo": "WOW"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": "WOWget_y_depXXX"})

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -102,7 +102,7 @@ def create_app_imperative():
     router = APIRouter()
     controller = Controller(router, openapi_tag={"name": "sample_controller"})
 
-    SampleController = controller.add_resource(SampleController)
+    controller.add_resource(SampleController)
     controller.route.add_api_route(
         "/",
         SampleController.root,

--- a/tests/test_inherit.py
+++ b/tests/test_inherit.py
@@ -52,6 +52,17 @@ class Controller(Base):
         id += self.x.create() + self.bla
         return Object(id=id)
 
+@parent_controller.resource()
+class Controller2(Base):
+    def __init__(self):
+        self.bla = 'ma'
+
+    @parent_controller.route.get(
+        "/step2", tags=["step2"], response_model=Object,
+    )
+    def hambu(self):
+        return Object(id="step2-%s" % self.bla)
+
 def create_app():
     app = FastAPI(
         title="A application using fastapi_router_controller",
@@ -60,6 +71,7 @@ def create_app():
     )
 
     app.include_router(Controller.router())
+    app.include_router(Controller2.router())
     return app
 
 class TestRoutes(unittest.TestCase):
@@ -72,7 +84,12 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"id": "12XXXfoo"})
 
-    def test_hambu(self):
+    def test_child1(self):
         response = self.client.get("/hambu")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"id": "hambu-foo"})
+
+    def test_step2(self):
+        response = self.client.get("/step2")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": "step2-ma"})


### PR DESCRIPTION
I've added imperative style of programming (no decorators) -> https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/configuration.html

Readded my `VISITED` code as `deepcopy` breaks the if you use the same parent controller twice it also breaks the imperative code (ApiRoute is always empty)

I've also added a test for both cases.

```python
...
def create_app_imperative():
    app = FastAPI(
        title="A sample application using fastapi_router_controller",
        version="0.1.0",
        openapi_tags=ControllersTags,
    )

    router = APIRouter()
    controller = Controller(router, openapi_tag={"name": "sample_controller"})

    controller.add_resource(SampleController)
    controller.route.add_api_route(
        "/",
        SampleController.root,
        tags=["sample_controller"],
        summary="return a sample object",
        response_model=SampleObject,
        methods=["GET"],
    )
    controller.route.add_api_route(
        "/hello", SampleController.hello, response_model=SampleObject, methods=["POST"]
    )
    app.include_router(SampleController.router())
    return app

```

We should probably add some docs to for usage ;)